### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ curl -L https://dl.google.com/go/go1.18.9.linux-amd64.tar.gz >/tmp/go1.18.9.linu
 tar -xf /tmp/go1.18.9.linux-amd64.tar.gz -C $HOME
 echo -e "export GOROOT=\"\$HOME/go\"" | tee -a ~/.bashrc
 echo -e "export PATH=\"\$HOME/go:\$PATH\"" | tee -a ~/.bashrc
+source ~/.profile
 go version
 ```
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,6 @@ nvm use v17.6.0
 curl -L https://dl.google.com/go/go1.18.9.linux-amd64.tar.gz >/tmp/go1.18.9.linux-amd64.tar.gz
 tar -xf /tmp/go1.18.9.linux-amd64.tar.gz -C $HOME
 echo -e "export GOROOT=\"\$HOME/go\"" | tee -a ~/.bashrc
-echo -e "export PATH=\"\$HOME/go:\$PATH\"" | tee -a ~/.bashrc
 source ~/.profile
 go version
 ```


### PR DESCRIPTION
curl -L https://dl.google.com/go/go1.18.9.linux-amd64.tar.gz >/tmp/go1.18.9.linux-amd64.tar.gz tar -xf /tmp/go1.18.9.linux-amd64.tar.gz -C $HOME
echo -e "export GOROOT=\"\$HOME/go\"" | tee -a ~/.bashrc echo -e "export PATH=\"\$HOME/go:\$PATH\"" | tee -a ~/.bashrc 

only may not work, 
will issue like : go: command not found Adding source ~/.profile will fix it.

Signed-off-by: Satya Raj Awasthi <77236280+SatyaRajAwasth1@users.noreply.github.com>